### PR TITLE
Escape /p switch strings

### DIFF
--- a/HowToBuild.md
+++ b/HowToBuild.md
@@ -35,8 +35,8 @@ Updateを適用し最新版を使用してください。大事なことなの�
 ```
 PS C:\Path\to\ffftp> git -C C:\Path\to\vcpkg apply -C0 --whitespace=fix (gi vcpkg\*.patch)
 PS C:\Path\to\ffftp> C:\Path\to\vcpkg\vcpkg --overlay-triplets=vcpkg/triplets install boost-regex:x86-windows-ffftp boost-regex:x64-windows-ffftp
-PS C:\Path\to\ffftp> MSBuild ffftp.sln /p:Configuration=Release;Platform=Win32
-PS C:\Path\to\ffftp> MSBuild ffftp.sln /p:Configuration=Release;Platform=x64
+PS C:\Path\to\ffftp> MSBuild ffftp.sln /p:"Configuration=Release;Platform=Win32"
+PS C:\Path\to\ffftp> MSBuild ffftp.sln /p:"Configuration=Release;Platform=x64"
 ```
 コンパイルの後、インストーラーが作成されます。`Release`ディレクトリに`ffftp-x86.msi`、`ffftp-x86.zip`、`ffftp-x64.msi`、`ffftp-x64.zip`が生成されます。
 


### PR DESCRIPTION
PowerShellにおいて`;`(セミコロン)は文末を表す。
```powershell
MSBuild ffftp.sln /p:Configuration=Release;Platform=Win32
```
は実際には
```powershell
MSBuild ffftp.sln /p:Configuration=Release
Platform=Win32
```
のように、2文として処理される。

`;`をエスケープする必要がある。

文字列を`""`で囲むほかに、 `` `; ``と個別にエスケープする方法もある。
このプルリクエストでは文字列を`""`で囲む方法を取った。